### PR TITLE
Bug fix for importSpecifier as path

### DIFF
--- a/src/importw.ts
+++ b/src/importw.ts
@@ -38,7 +38,7 @@ export async function importw<T = any>(
   { name, deno = false }: ImportWorkerOptions = {},
 ): Promise<ImportWorker<T>> {
   const url = new URL(path, `file://${Deno.cwd()}/`);
-  const importSpecifier = url.protocol === "file:" ? url.pathname : url.href;
+  const importSpecifier = url.href;
 
   const importWorker = new Worker(import.meta.url, {
     type: "module",


### PR DESCRIPTION
importSpecifier should be url format. For local file, it should be `file:///user/user1/example/worker/function1.ts`, not `/user/user1/example/worker/function1.ts`.    Tested on deno 1.14.1 

```typescript 
import {
    importw,
    release,
    worker,
} from "https://deno.land/x/importw@1.0.0/mod.ts";

// Import module from within a worker.
const worker1 = await importw(
    "./worker/function1.ts",
    {
        name: "function1.ts",
        deno: false,
    },
);
```